### PR TITLE
Fix ansible-sshd version

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -141,7 +141,7 @@
 - name: sshd
   scm: git
   src: https://github.com/willshersystems/ansible-sshd
-  version: 0.4.5
+  version: v0.4.5
 - name: bird
   scm: git
   src: https://github.com/logan2211/ansible-bird


### PR DESCRIPTION
The role ansible-sshd has replaced the tag 0.4.5 with v0.4.5 [1] causing
a failure when attempting to install the role defined in this
repository. This change updates the version defined to the SHA
referenced by the tag v0.4.5.

JIRA: RE-2208

[1] https://github.com/willshersystems/ansible-sshd/issues/98

Change-Id: I82f9317783b8f8d5e908028c5cf791825ee59aa4