### PR TITLE
Removing linux-image-extra package

### DIFF
--- a/tests/roles/bootstrap-host/vars/ubuntu.yml
+++ b/tests/roles/bootstrap-host/vars/ubuntu.yml
@@ -21,7 +21,7 @@ packages_install:
   - ethtool
   - git-core
   - ipython
-  - linux-image-extra-{{ ansible_kernel }}
+  - linux-modules-extra-{{ ansible_kernel }}
   - lvm2
   - python2.7
   - python-dev


### PR DESCRIPTION
It looks like builds have been failing since the 17th due to the following error:

  - "No package matching 'linux-image-extra-4.4.0-143-generic' is available"

It matches the following bug report.

  - https://bugs.launchpad.net/openstack-ansible/+bug/1783342

This patch is to remove the linux-image-extra package as it looks like its
no longer available in the repos.