### PR TITLE
Updating to install either extra modules based on kernel version

### DIFF
--- a/tests/roles/bootstrap-host/vars/ubuntu-14.04.yml
+++ b/tests/roles/bootstrap-host/vars/ubuntu-14.04.yml
@@ -1,0 +1,36 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+packages_install:
+  - apt-transport-https
+  - bridge-utils
+  - build-essential
+  - curl
+  - ethtool
+  - git-core
+  - ipython
+  - "{% if hostvars[inventory_hostname]['ansible_kernel'] | version_compare('3.13.0-166', '>=') %}linux-modules-extra-{{ ansible_kernel }}{% else %}linux-image-extra-{{ ansible_kernel }}{% endif %}"
+  - lvm2
+  - python2.7
+  - python-dev
+  - tmux
+  - vim
+  - vlan
+  - xfsprogs
+  - iputils-tracepath
+
+packages_remove:
+  - libmysqlclient18
+  - mysql-common

--- a/tests/roles/bootstrap-host/vars/ubuntu-16.04.yml
+++ b/tests/roles/bootstrap-host/vars/ubuntu-16.04.yml
@@ -21,7 +21,7 @@ packages_install:
   - ethtool
   - git-core
   - ipython
-  - linux-modules-extra-{{ ansible_kernel }}
+  - "{% if hostvars[inventory_hostname]['ansible_kernel'] | version_compare('4.4.0-143', '>=') %}linux-modules-extra-{{ ansible_kernel }}{% else %}linux-image-extra-{{ ansible_kernel }}{% endif %}"
   - lvm2
   - python2.7
   - python-dev


### PR DESCRIPTION
It looks like some of the rpc-openstack tests run on older images
without updating. The following changes should make a decision
to install either the linux-image-extra or linux-modules-extra
based on kernel versions.  The name changed on version 3.13.0-166
for trusy and 4.4.0-143-generic for xenial. Newton shouldn't be
installed on bionic as far as I'm aware.