### PR TITLE
Updates newton to use rcbops openstack_hosts

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -44,8 +44,8 @@
   version: newton-eol
 - name: openstack_hosts
   scm: git
-  src: https://git.openstack.org/openstack/openstack-ansible-openstack_hosts
-  version: newton-eol
+  src: https://github.com/rcbops/openstack-ansible-openstack_hosts
+  version: stable/newton
 - name: os_keystone
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-os_keystone


### PR DESCRIPTION
Necessary for leapfrog as it uses ansible-role-requirements.yml from openstack-ansible and rpc-openstack.  The newton-eol tag will also need to be rewritten to point to this once it merges.